### PR TITLE
Fix forward worker restart after init retry fail

### DIFF
--- a/openprocurement/bridge/competitivedialogue/databridge.py
+++ b/openprocurement/bridge/competitivedialogue/databridge.py
@@ -116,6 +116,12 @@ def check_status_response(func):
         return response
     return func_wrapper
 
+def wait_initialization(func):
+    def func_wrapper(obj, *args, **kwargs):
+        gevent.wait(objects=[obj.initialization_event])
+        return func(obj, *args, **kwargs)
+    return func_wrapper
+
 
 class TendersClientSync(BaseTendersClientSync):
 
@@ -644,8 +650,8 @@ class CompetitiveDialogueDataBridge(object):
                 self.dialog_stage2_id_queue.put(dialog)
             gevent.sleep(0)
 
+    @wait_initialization()
     def get_competitive_dialogue_forward(self):
-        gevent.wait([self.initialization_event])
         logger.info('Start forward data sync worker...')
         params = {'opt_fields': 'status,procurementMethodType', 'mode': '_all_'}
         try:

--- a/openprocurement/bridge/competitivedialogue/databridge.py
+++ b/openprocurement/bridge/competitivedialogue/databridge.py
@@ -213,7 +213,6 @@ class CompetitiveDialogueDataBridge(object):
             raise ValueError
         else:
             assert 'descending' not in params
-            gevent.wait([self.initialization_event])
             self.initialization_event.clear()
             params['offset'] = self.initial_sync_point['forward_offset']
             logger.info("Starting forward sync from offset {}".format(params['offset']))
@@ -646,6 +645,7 @@ class CompetitiveDialogueDataBridge(object):
             gevent.sleep(0)
 
     def get_competitive_dialogue_forward(self):
+        gevent.wait([self.initialization_event])
         logger.info('Start forward data sync worker...')
         params = {'opt_fields': 'status,procurementMethodType', 'mode': '_all_'}
         try:


### PR DESCRIPTION
Перенесен `gevent.wait` вне метода @retry, для избежания множественного линкования. 

